### PR TITLE
BUGFIX/MINOR(openio-service): fix log ownership on Debian

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,4 +4,7 @@ _service_directories:
   - path: "{{ openio_service_inventory_dir }}"
   - path: "{{ openio_service_conf_dir }}"
   - path: "{{ openio_service_log_dir }}"
+    mode: "{{ '0750' if ansible_os_family == 'RedHat' else '0770' }}"
+    owner: "{{ 'openio' if ansible_os_family == 'RedHat' else 'syslog' }}"
+    group: "openio"
 ...


### PR DESCRIPTION
 ##### SUMMARY

log directory was owned by user `openio` but it must be owned by user
`syslog` on `Debian` distributions has `rsyslog` runs as user `syslog`
(while it runs with user `root` on RedHat servers)

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION