### PR TITLE
BUGFIX/MINOR(openio-service): set LANG env for syslog services

### DIFF
--- a/templates/gridinit.conf.j2
+++ b/templates/gridinit.conf.j2
@@ -27,8 +27,11 @@ on_die={{ service.on_die | d('respawn') }}
 group={{ service.group | d(openio_service_gridinit_default_group) }}
 uid={{ service.uid | d('openio') }}
 gid={{ service.gid | d('openio') }}
-{% set default_env = {"PATH": "/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin"} %}
-{% set env = default_env | combine(service.env | d({})) %}
+{% set env = {"PATH": "/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin"} %}
+{% if 'redirect_stdout_to_syslog' in service %}
+{%   set env = env | combine({"LANG": "en_US.UTF-8"}) %}
+{% endif %}
+{% set env = env | combine(service.env | d({})) %}
 {% for k,v in env.items() %}
 env.{{ k }}={{ v }}
 {% endfor %}


### PR DESCRIPTION
 ##### SUMMARY

`/usr/bin/gridinit-syslog-logger` use `LANG` environment variable to
determine how it should decode logs read from its child process.

With an empty environment, the default was to decode logs as `ascii` and
it could rise an exception with UTF8 logs.

To fix this, this PR adds the `LANG=en_us.UTF8` environment variable to
each services that use the `redirect_stdout_to_syslog` option.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION