### PR TITLE
BUGFIX/MINOR(openio-service): Fix check mode on check uri

### DIFF
--- a/tasks/checks/uri.yml
+++ b/tasks/checks/uri.yml
@@ -42,5 +42,6 @@
   when:
     - not openio_service_maintenance_mode | bool
     - "'uri' in item and item.uri.url is string and item.uri.url | length > 0"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: configure
 ...


### PR DESCRIPTION
 ##### SUMMARY

Ignore fatal error on a dry run.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```console
TASK [openio-service : [grafana-0] Check URL http://172.25.10.51:6910/api/health] *******************
Friday 26 June 2020  21:44:27 +0000 (0:00:00.083)       0:01:52.959 ***********
[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or
{% %}. Found: {{ item.until | d('_return is success') }}
FAILED - RETRYING: [grafana-0] Check URL http://172.25.10.51:6910/api/health
 (10 retries left).
FAILED - RETRYING: [grafana-0] Check URL http://172.25.10.51:6910/api/health
 (9 retries left).
FAILED - RETRYING: [grafana-0] Check URL http://172.25.10.51:6910/api/health
 (8 retries left).
FAILED - RETRYING: [grafana-0] Check URL http://172.25.10.51:6910/api/health
 (7 retries left).
FAILED - RETRYING: [grafana-0] Check URL http://172.25.10.51:6910/api/health
 (6 retries left).
FAILED - RETRYING: [grafana-0] Check URL http://172.25.10.51:6910/api/health
 (5 retries left).
FAILED - RETRYING: [grafana-0] Check URL http://172.25.10.51:6910/api/health
 (4 retries left).
FAILED - RETRYING: [grafana-0] Check URL http://172.25.10.51:6910/api/health
 (3 retries left).
FAILED - RETRYING: [grafana-0] Check URL http://172.25.10.51:6910/api/health
 (2 retries left).
FAILED - RETRYING: [grafana-0] Check URL http://172.25.10.51:6910/api/health
 (1 retries left).
fatal: [node-admin]: FAILED! => changed=false
  attempts: 10
  msg: remote module (uri) does not support check mode
```